### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WiFi101OTA
-version=1.0.2
+version=1.1.0
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Update sketches on your board over WiFi

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Requires an Arduino/Genuino SAMD board
 category=Other
 url=http://www.arduino.cc/en/Reference/WiFi101OTA
 architectures=samd
+depends=SerialFlash, WiFi101


### PR DESCRIPTION
Specifying the library dependencies in the depends field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.